### PR TITLE
Stacksafe LEDArray

### DIFF
--- a/leddriver/apps/squareDiagonal.cpp
+++ b/leddriver/apps/squareDiagonal.cpp
@@ -35,14 +35,14 @@ int main()
     sleep_ms(1000);
     std::cout << "LED Driver SquareDiagonal" << std::endl;
 
-    LEDDriver::LEDArray *ledArr = new LEDDriver::LEDArray(pio0);
+    LEDDriver::LEDArray ledArr(pio0);
 
     auto img = CreateSquareDiagonal();
-    img.SendToLEDArray(*ledArr);
+    img.SendToLEDArray(ledArr);
     while (true)
     {
         auto targetTime = make_timeout_time_ms(5);
-        ledArr->SendBuffer();
+        ledArr.SendBuffer();
         sleep_until(targetTime);
     }
 }

--- a/leddriver/apps/testCard.cpp
+++ b/leddriver/apps/testCard.cpp
@@ -43,14 +43,14 @@ int main()
     sleep_ms(1000);
     std::cout << "LED Driver Testcard" << std::endl;
 
-    LEDDriver::LEDArray *ledArr = new LEDDriver::LEDArray(pio0);
+    LEDDriver::LEDArray ledArr(pio0);
 
     auto img = CreateTestCard();
-    img.SendToLEDArray(*ledArr);
+    img.SendToLEDArray(ledArr);
     while (true)
     {
         auto targetTime = make_timeout_time_ms(5);
-        ledArr->SendBuffer();
+        ledArr.SendBuffer();
         sleep_until(targetTime);
     }
 }

--- a/leddriver/include/leddriver/ledarray.hpp
+++ b/leddriver/include/leddriver/ledarray.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <memory>
 
 #include "hardware/pio.h"
 
@@ -29,11 +30,13 @@ namespace LEDDriver
 
         void SendBuffer();
 
+        typedef std::array<uint32_t, (nRows / 2) * (nWordsPerRow * nFrames)> Buffer;
+
     private:
         std::atomic<unsigned char> activeBuffer;
         LEDDriver::PIOCommunicator comms;
 
-        std::array<uint32_t, (nRows / 2) * (nWordsPerRow * nFrames)> outputBuffer0, outputBuffer1;
+        std::unique_ptr<Buffer> outputBuffer0, outputBuffer1;
 
         bool is_pixel_on(const uint8_t value, const unsigned int iFrame) const;
         std::array<uint32_t, LEDArray::nWordsPerRow> ConstructRowPair(

--- a/leddriver/src/ledarray.cpp
+++ b/leddriver/src/ledarray.cpp
@@ -18,8 +18,8 @@ namespace LEDDriver
 {
     LEDArray::LEDArray(PIO targetPio) : activeBuffer(0),
                                         comms(),
-                                        outputBuffer0(),
-                                        outputBuffer1()
+                                        outputBuffer0(std::make_unique<Buffer>()),
+                                        outputBuffer1(std::make_unique<Buffer>())
     {
         std::set<uint> outputPins = {
             clk, latch, outputEnable,
@@ -71,11 +71,11 @@ namespace LEDDriver
         // We will update the buffer not in use
         if (this->activeBuffer.load() == 0)
         {
-            buffer = this->outputBuffer1.data();
+            buffer = this->outputBuffer1->data();
         }
         else
         {
-            buffer = this->outputBuffer0.data();
+            buffer = this->outputBuffer0->data();
         }
 
         // We send rows out two at a time, separated by 16 rows
@@ -147,11 +147,11 @@ namespace LEDDriver
         uint32_t *buffer;
         if (this->activeBuffer.load() == 0)
         {
-            buffer = this->outputBuffer0.data();
+            buffer = this->outputBuffer0->data();
         }
         else
         {
-            buffer = this->outputBuffer1.data();
+            buffer = this->outputBuffer1->data();
         }
 
         for (unsigned int i = 0; i < nRows / 2; i++)

--- a/main.cpp
+++ b/main.cpp
@@ -77,7 +77,7 @@ int main()
     sleep_ms(1000);
     std::cout << "LED Driver" << std::endl;
 
-    LEDDriver::LEDArray *ledArr = new LEDDriver::LEDArray(pio0);
+    LEDDriver::LEDArray ledArr(pio0);
 
     // Set up Life Board
     std::cout << "Creating the grid" << std::endl;
@@ -90,13 +90,13 @@ int main()
     std::cout << "Starting core1" << std::endl;
     multicore_launch_core1(core1Entry);
     std::cout << "Sending address of array object" << std::endl;
-    multicore_fifo_push_blocking(reinterpret_cast<uint32_t>(ledArr));
+    multicore_fifo_push_blocking(reinterpret_cast<uint32_t>(&ledArr));
 
     std::cout << "Starting Main Loop" << std::endl;
 
     unsigned long itCount = 0;
     auto img = ImageFromSparseLife(grid, itCount);
-    img.SendToLEDArray(*ledArr);
+    img.SendToLEDArray(ledArr);
     sleep_ms(1000);
     while (true)
     {
@@ -104,7 +104,7 @@ int main()
         auto targetTime = make_timeout_time_ms(100);
         grid.Update();
         auto nxtImage = ImageFromSparseLife(grid, itCount);
-        nxtImage.SendToLEDArray(*ledArr);
+        nxtImage.SendToLEDArray(ledArr);
         sleep_until(targetTime);
     }
 


### PR DESCRIPTION
Update the `LEDArray` class so that it heap allocates its buffers. Stack space is precious on the Pico and it doesn't throw a nice error when the stack overflows. Before this, the workaround was to heap allocate the entire `LEDArray` object.

Closes #16 