### PR TITLE
Add selectable patterns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ pico_sdk_init()
 add_executable(${PROJECT_NAME}
     main.cpp
     colourvector.cpp
+    gridSetup.cpp
 )
 
 

--- a/gridSetup.cpp
+++ b/gridSetup.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <random>
 #include <sstream>
 
 #include "sparselife/cellpattern.hpp"
@@ -12,6 +13,23 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
     switch (patternSelect)
     {
     case 0:
+        std::cout << "Adding soup" << std::endl;
+        targetGrid.ClearCells();
+        {
+            std::default_random_engine generator;
+            std::uniform_int_distribution<int> distX(0, targetGrid.nx - 1);
+            std::uniform_int_distribution<int> distY(0, targetGrid.ny - 1);
+            for (auto i = 0; i < 500; ++i)
+            {
+                auto x = distX(generator);
+                auto y = distY(generator);
+
+                targetGrid.AddCell(SparseLife::Cell(x, y));
+            }
+        }
+        break;
+
+    case 1:
         std::cout << "Adding Coe and Fireships" << std::endl;
         targetGrid.ClearCells();
         {
@@ -33,8 +51,9 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         }
         break;
 
-    case 1:
+    case 2:
         std::cout << "Adding oscillators" << std::endl;
+        targetGrid.ClearCells();
         {
             auto cellStream = std::stringstream(achimsp144Cells);
             SparseLife::CellPattern cp;
@@ -51,8 +70,9 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         }
         break;
 
-    case 2:
+    case 3:
         std::cout << "Adding lobster" << std::endl;
+        targetGrid.ClearCells();
         {
             auto cellStream = std::stringstream(lobsterRLE);
             SparseLife::CellPattern cp;
@@ -63,6 +83,6 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         break;
 
     default:
-        std::cerr << "Pattern selector " << patternSelect << " unrecognised" << std::endl;
+        std::cout << "Pattern selector " << patternSelect << " unrecognised" << std::endl;
     }
 }

--- a/gridSetup.cpp
+++ b/gridSetup.cpp
@@ -15,7 +15,7 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
     switch (patternSelect)
     {
     case 0:
-        std::cout << "Adding soup" << std::endl;
+        std::cout << "Creating soup" << std::endl;
         targetGrid.ClearCells();
         {
             auto seed = to_ms_since_boot(get_absolute_time());
@@ -33,7 +33,7 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         break;
 
     case 1:
-        std::cout << "Adding Coe and Fireships" << std::endl;
+        std::cout << "Creating Coe and Fireships" << std::endl;
         targetGrid.ClearCells();
         {
             auto cellStream = std::stringstream(coeShipCells);
@@ -55,7 +55,7 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         break;
 
     case 2:
-        std::cout << "Adding oscillators" << std::endl;
+        std::cout << "Creating oscillators" << std::endl;
         targetGrid.ClearCells();
         {
             auto cellStream = std::stringstream(achimsp144Cells);
@@ -74,7 +74,7 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         break;
 
     case 3:
-        std::cout << "Adding lobster" << std::endl;
+        std::cout << "Creating lobster" << std::endl;
         targetGrid.ClearCells();
         {
             auto cellStream = std::stringstream(lobsterRLE);
@@ -82,6 +82,36 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
             cp.LoadRLEFromStream(cellStream);
             cp.Translate(0, 0);
             targetGrid.AddCells(cp.GetCells());
+        }
+        break;
+
+    case 4:
+        std::cout << "Creating LWSS synthesis" << std::endl;
+        targetGrid.ClearCells();
+        {
+            auto cellStream = std::stringstream(lwssSynthRLE);
+            SparseLife::CellPattern cp;
+            cp.LoadRLEFromStream(cellStream);
+            cp.Translate(5, 5);
+            targetGrid.AddCells(cp.GetCells());
+        }
+        break;
+
+    case 9:
+        std::cout << "Inserting some soup" << std::endl;
+        // Note _no_ clearing of the grid
+        {
+            auto seed = to_ms_since_boot(get_absolute_time());
+            std::default_random_engine generator(seed);
+            std::uniform_int_distribution<int> distX(0, targetGrid.nx - 1);
+            std::uniform_int_distribution<int> distY(0, targetGrid.ny - 1);
+            for (auto i = 0; i < 20; ++i)
+            {
+                auto x = distX(generator);
+                auto y = distY(generator);
+
+                targetGrid.AddCell(SparseLife::Cell(x, y));
+            }
         }
         break;
 

--- a/gridSetup.cpp
+++ b/gridSetup.cpp
@@ -2,6 +2,8 @@
 #include <random>
 #include <sstream>
 
+#include "pico/time.h"
+
 #include "sparselife/cellpattern.hpp"
 
 #include "cells.hpp"
@@ -16,7 +18,8 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
         std::cout << "Adding soup" << std::endl;
         targetGrid.ClearCells();
         {
-            std::default_random_engine generator;
+            auto seed = to_ms_since_boot(get_absolute_time());
+            std::default_random_engine generator(seed);
             std::uniform_int_distribution<int> distX(0, targetGrid.nx - 1);
             std::uniform_int_distribution<int> distY(0, targetGrid.ny - 1);
             for (auto i = 0; i < 500; ++i)

--- a/gridSetup.cpp
+++ b/gridSetup.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+
+#include "cells.hpp"
+
+#include "gridSetup.hpp"
+
+void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect)
+{
+    switch (patternSelect)
+    {
+        case 0:
+            
+
+        default:
+            std::cerr << "Pattern selector " << patternSelect << " unrecognised" << std::endl;
+    }
+}

--- a/gridSetup.cpp
+++ b/gridSetup.cpp
@@ -1,4 +1,7 @@
 #include <iostream>
+#include <sstream>
+
+#include "sparselife/cellpattern.hpp"
 
 #include "cells.hpp"
 
@@ -8,10 +11,58 @@ void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect
 {
     switch (patternSelect)
     {
-        case 0:
-            
+    case 0:
+        std::cout << "Adding Coe and Fireships" << std::endl;
+        targetGrid.ClearCells();
+        {
+            auto cellStream = std::stringstream(coeShipCells);
+            SparseLife::CellPattern cp;
+            cp.LoadFromStream(cellStream);
+            cp.Translate(2, 4);
+            cp.ExchangeXY();
+            targetGrid.AddCells(cp.GetCells());
+        }
 
-        default:
-            std::cerr << "Pattern selector " << patternSelect << " unrecognised" << std::endl;
+        {
+            auto cellStream = std::stringstream(fireShipCells);
+            SparseLife::CellPattern cp;
+            cp.LoadFromStream(cellStream);
+            cp.Translate(16, 8);
+            cp.FlipY();
+            targetGrid.AddCells(cp.GetCells());
+        }
+        break;
+
+    case 1:
+        std::cout << "Adding oscillators" << std::endl;
+        {
+            auto cellStream = std::stringstream(achimsp144Cells);
+            SparseLife::CellPattern cp;
+            cp.LoadFromStream(cellStream);
+            cp.Translate(2, 1);
+            targetGrid.AddCells(cp.GetCells());
+        }
+        {
+            auto cellStream = std::stringstream(queenBeeShuttleCells);
+            SparseLife::CellPattern cp;
+            cp.LoadFromStream(cellStream);
+            cp.Translate(4, 23);
+            targetGrid.AddCells(cp.GetCells());
+        }
+        break;
+
+    case 2:
+        std::cout << "Adding lobster" << std::endl;
+        {
+            auto cellStream = std::stringstream(lobsterRLE);
+            SparseLife::CellPattern cp;
+            cp.LoadRLEFromStream(cellStream);
+            cp.Translate(0, 0);
+            targetGrid.AddCells(cp.GetCells());
+        }
+        break;
+
+    default:
+        std::cerr << "Pattern selector " << patternSelect << " unrecognised" << std::endl;
     }
 }

--- a/gridSetup.hpp
+++ b/gridSetup.hpp
@@ -1,3 +1,5 @@
 #pragma once
 
+#include "sparselife/sparselife.hpp"
+
 void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect);

--- a/gridSetup.hpp
+++ b/gridSetup.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void SetInitialState(SparseLife::SparseLife &targetGrid, const int patternSelect);

--- a/main.cpp
+++ b/main.cpp
@@ -59,7 +59,7 @@ void SetInitialState(SparseLife::SparseLife &initialGrid)
     }
 #endif
 
-#if 0
+#if 1
     {
         auto cellStream = std::stringstream(achimsp144Cells);
         SparseLife::CellPattern cp;
@@ -77,6 +77,8 @@ void SetInitialState(SparseLife::SparseLife &initialGrid)
         initialGrid.AddCells(cp.GetCells());
     }
 #endif
+
+#if 0
     {
         auto cellStream = std::stringstream(lobsterRLE);
         SparseLife::CellPattern cp;
@@ -85,6 +87,7 @@ void SetInitialState(SparseLife::SparseLife &initialGrid)
         std::cout << "Adding cell count " << cp.GetCells().size() << std::endl;
         initialGrid.AddCells(cp.GetCells());
     }
+#endif
 }
 
 int main()

--- a/main.cpp
+++ b/main.cpp
@@ -1,14 +1,14 @@
 #include <iostream>
 #include <sstream>
 
+#include "pico/stdio.h"
 #include "pico/stdlib.h"
 #include "pico/time.h"
 
-#include "cells.hpp"
-#include "sparselife/cellpattern.hpp"
 #include "sparselife/sparselife.hpp"
 
 #include "colourvector.hpp"
+#include "gridSetup.hpp"
 
 #include "leddriver/ledarray.hpp"
 #include "leddriver/ledimage.hpp"
@@ -35,60 +35,6 @@ LEDDriver::LEDImage ImageFromSparseLife(const SparseLife::SparseLife &grid, cons
     return result;
 }
 
-void SetInitialState(SparseLife::SparseLife &initialGrid)
-{
-#if 0
-    {
-        auto cellStream = std::stringstream(coeShipCells);
-        SparseLife::CellPattern cp;
-        cp.LoadFromStream(cellStream);
-        cp.Translate(2, 4);
-        cp.ExchangeXY();
-        std::cout << "Adding cell count " << cp.GetCells().size() << std::endl;
-        initialGrid.AddCells(cp.GetCells());
-    }
-
-    {
-        auto cellStream = std::stringstream(fireShipCells);
-        SparseLife::CellPattern cp;
-        cp.LoadFromStream(cellStream);
-        cp.Translate(16, 8);
-        cp.FlipY();
-        std::cout << "Adding cell count " << cp.GetCells().size() << std::endl;
-        initialGrid.AddCells(cp.GetCells());
-    }
-#endif
-
-#if 1
-    {
-        auto cellStream = std::stringstream(achimsp144Cells);
-        SparseLife::CellPattern cp;
-        cp.LoadFromStream(cellStream);
-        cp.Translate(2, 1);
-        std::cout << "Adding cell count " << cp.GetCells().size() << std::endl;
-        initialGrid.AddCells(cp.GetCells());
-    }
-    {
-        auto cellStream = std::stringstream(queenBeeShuttleCells);
-        SparseLife::CellPattern cp;
-        cp.LoadFromStream(cellStream);
-        cp.Translate(4, 23);
-        std::cout << "Adding cell count " << cp.GetCells().size() << std::endl;
-        initialGrid.AddCells(cp.GetCells());
-    }
-#endif
-
-#if 0
-    {
-        auto cellStream = std::stringstream(lobsterRLE);
-        SparseLife::CellPattern cp;
-        cp.LoadRLEFromStream(cellStream);
-        cp.Translate(0, 0);
-        std::cout << "Adding cell count " << cp.GetCells().size() << std::endl;
-        initialGrid.AddCells(cp.GetCells());
-    }
-#endif
-}
 
 int main()
 {
@@ -104,7 +50,7 @@ int main()
 
     // Populate the Life board
     std::cout << "Adding initial cells to grid" << std::endl;
-    SetInitialState(grid);
+    SetInitialState(grid, 0);
 
     std::cout << "Starting core1" << std::endl;
     LEDDriver::LaunchOnCore1(&ledArr, 5);
@@ -118,6 +64,11 @@ int main()
     while (true)
     {
         ++itCount;
+        auto ch = getchar_timeout_us(0);
+        if( ch != PICO_ERROR_TIMEOUT)
+        {
+            SetInitialState(grid, ch - '0');
+        }
         auto targetTime = make_timeout_time_ms(100);
         grid.Update();
         auto nxtImage = ImageFromSparseLife(grid, itCount);

--- a/sparselife/include/sparselife/sparselife.hpp
+++ b/sparselife/include/sparselife/sparselife.hpp
@@ -20,6 +20,8 @@ namespace SparseLife
         void AddCell(const Cell cell);
         void AddCells(const std::set<Cell> &cells);
 
+        void ClearCells();
+
         std::vector<Cell> GetNeighbours(const Cell c) const;
         std::unique_ptr<std::set<Cell>> ApplyRules(const std::set<Cell> &cellGrid) const;
 

--- a/sparselife/src/sparselife.cpp
+++ b/sparselife/src/sparselife.cpp
@@ -26,6 +26,11 @@ namespace SparseLife
         this->activeCells->insert(cells.begin(), cells.end());
     }
 
+    void SparseLife::ClearCells()
+    {
+        this->activeCells->clear();
+    }
+
     std::vector<Cell>
     SparseLife::GetNeighbours(const Cell c) const
     {


### PR DESCRIPTION
Enable patterns to be selected while code is running. This also adds two 'soup' options; one which generates a random grid, and another which just injects some cells into the existing grid.